### PR TITLE
Adds compatibility for newrelic python api v6 and up

### DIFF
--- a/newrelic/__manifest__.py
+++ b/newrelic/__manifest__.py
@@ -1,7 +1,7 @@
 {
     'name': 'NewRelic Instrumentation',
     'description': 'Wraps requests etc.',
-    'version': '1.0',
+    'version': '1.1',
     'website': 'https://hibou.io/',
     'author': 'Hibou Corp. <hello@hibou.io>',
     'license': 'AGPL-3',
@@ -9,6 +9,9 @@
     'depends': [
         'web',
     ],
+    'external_dependencies': {
+        "python": ["newrelic"],
+    },    
     "installable": True,
     "application": False,
 }


### PR DESCRIPTION
Because of a breaking introduced by the newrelic plugin v6 and up, `ignore_status_code` is not exported anymore from `newrelic.agent`. Also `record_exception` has been superseded by the new `notice_error` API as mentioned [here](https://docs.newrelic.com/docs/release-notes/agent-release-notes/python-release-notes/python-agent-60400157) in the release notes. This PR makes the adjustments needed to ensure compatibility with newer plugin versions and is based on the [flask component hook](https://github.com/newrelic/newrelic-python-agent/blob/main/newrelic/hooks/component_flask_rest.py#L37).