### PR TITLE
[IMP] newrelic: wrap target server initialization

### DIFF
--- a/newrelic/__init__.py
+++ b/newrelic/__init__.py
@@ -1,10 +1,12 @@
 import os
 from . import controllers
+from odoo.tools import config
 
 import logging 
 _logger = logging.getLogger(__name__)
 
-try:
+
+def initialization():
     import odoo
     target = odoo.service.server.server
     if not target:
@@ -19,7 +21,6 @@ try:
     if instrumented:
         _logger.info("NewRelic instrumented already")
     else:
-        import odoo.tools.config as config
         import newrelic.agent
 
 
@@ -121,6 +122,12 @@ try:
 
         target = odoo.http.WebRequest
         target._handle_exception = _nr_wrapper_handle_exception_(target._handle_exception)
+
+
+try:
+    # the Odoo server will stop after its initialization, server will not be available for monkey-patching
+    if not config.get("stop_after_init"):
+        initialization()
 
 except ImportError:
     _logger.warn('newrelic python module not installed or other missing module')


### PR DESCRIPTION
It breaks while exporting odoo translations.` odoo-community/odoo-bin -c odoo.conf -d {database_name} --workers=0 --no-http --stop-after-init --i18n-export={export_path} --modules={module_name} -l nl_NL`. This PR skips target server initialization if stop-after-init argument is provided

Traceback:
```
Traceback (most recent call last):
  File "/newrelic/__init__.py", line 19, in <module>
    instrumented = target._nr_instrumented
AttributeError: 'NoneType' object has no attribute '_nr_instrumented'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  ...
    odoo.modules.registry.Registry.new(database, update_module=True)
  File "/odoo-community/odoo/modules/registry.py", line 89, in new
    odoo.modules.load_modules(registry._db, force_demo, status, update_module)
  File "/odoo-community/odoo/modules/loading.py", line 455, in load_modules
    processed_modules += load_marked_modules(cr, graph,
  File "/odoo-community/odoo/modules/loading.py", line 347, in load_marked_modules
    loaded, processed = load_module_graph(
  File "/odoo-community/odoo/modules/loading.py", line 179, in load_module_graph
    load_openerp_module(package.name)
  File "/odoo-community/odoo/modules/module.py", line 385, in load_openerp_module
    __import__('odoo.addons.' + module_name)
  File "/newrelic/__init__.py", line 21, in <module>
    instrumented = target._nr_instrumented = False
AttributeError: 'NoneType' object has no attribute '_nr_instrumented'
```
